### PR TITLE
find_test_by_frame: ignore exceptions

### DIFF
--- a/pytest_pdb.py
+++ b/pytest_pdb.py
@@ -9,8 +9,11 @@ def find_test_by_frame(currentframe):
     prev = frame
     while frame:
         for value in frame.f_locals.values():
-            if isinstance(value, pytest.Item):
-                return (value, prev)
+            try:
+                if isinstance(value, pytest.Item):
+                    return (value, prev)
+            except Exception:
+                pass
         prev = frame
         frame = frame.f_back
     return (None, currentframe)


### PR DESCRIPTION
Django might raise ImproperlyConfigured here:

    ../../Vcs/django/django/core/mail/__init__.py:1: in <module>
        __import__('pdb').set_trace()
    .venv/lib/python3.7/site-packages/pytest_pdb.py:145: in pytest_enter_pdb
        (test, frame) = find_test_by_frame(curframe)
    .venv/lib/python3.7/site-packages/pytest_pdb.py:12: in find_test_by_frame
        if isinstance(value, pytest.Item):
    ../../Vcs/django/django/utils/functional.py:213: in inner
        self._setup()
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    self = <LazySettings [Unevaluated]>, name = None

        def _setup(self, name=None):
            """
            Load the settings module pointed to by the environment variable. This
            is used the first time settings are needed, if the user hasn't
            configured settings manually.
            """
            settings_module = os.environ.get(ENVIRONMENT_VARIABLE)
            if not settings_module:
                desc = ("setting %s" % name) if name else "settings"
                raise ImproperlyConfigured(
                    "Requested %s, but settings are not configured. "
                    "You must either define the environment variable %s "
                    "or call settings.configure() before accessing settings."
    >               % (desc, ENVIRONMENT_VARIABLE))
    E           django.core.exceptions.ImproperlyConfigured: Requested settings, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.

    ../../Vcs/django/django/conf/__init__.py:42: ImproperlyConfigured